### PR TITLE
Update Json settings to ignore null values

### DIFF
--- a/ocpp-sharp/OcppJson.cs
+++ b/ocpp-sharp/OcppJson.cs
@@ -13,7 +13,8 @@ public static class OcppJson
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         UnmappedMemberHandling = JsonUnmappedMemberHandling.Skip,
         NumberHandling = JsonNumberHandling.AllowReadingFromString | JsonNumberHandling.AllowNamedFloatingPointLiterals,
-        ReferenceHandler = ReferenceHandler.IgnoreCycles
+        ReferenceHandler = ReferenceHandler.IgnoreCycles,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
     };
 
     private static readonly Dictionary<ProtocolVersion, Dictionary<CiString, Type>> messageRequestTypeMap; // OCPP request classes


### PR DESCRIPTION
I updated Json settings that the null values are not transfered. Without this it was not working on [SmartEVSE Charging stations](https://www.smartevse.nl/).

It changes that the null-Values on JSON are ignored and not written any more on the Json message, then it works with SmartEVSE. Other stations didn't have a problem with this null-values, and of course stations have no problem if the null values are missing.

So instead of

    "chargingProfileId":1,"transactionId":null,"stackLevel":5,"chargingProfilePurpose":"TxProfile","chargingProfileKind":"Absolute","recurrencyKind":null,"validFrom":null,"validTo":null, ...

the message results in

    "chargingProfileId":1,"stackLevel":5,"chargingProfilePurpose":"TxProfile","chargingProfileKind":"Absolute", ...