### PR TITLE
Add support for async handlers

### DIFF
--- a/ocpp-sharp/Client/ClientRequestHandler.cs
+++ b/ocpp-sharp/Client/ClientRequestHandler.cs
@@ -5,7 +5,8 @@ namespace OcppSharp.Client;
 public class ClientRequestHandler
 {
     public Type OnType { get; }
-    public RequestPayloadHandlerDelegate Handler { get; }
+    public RequestPayloadHandlerDelegate? Handler { get; } = null;
+    public RequestPayloadHandlerDelegateAsync? HandlerAsync { get; } = null;
 
     public ClientRequestHandler(Type payloadType, RequestPayloadHandlerDelegate handler)
     {
@@ -13,8 +14,22 @@ public class ClientRequestHandler
         Handler = handler;
     }
 
-    public ResponsePayload Handle(OcppSharpClient client, RequestPayload request)
+    public ClientRequestHandler(Type payloadType, RequestPayloadHandlerDelegateAsync handlerAsync)
     {
+        OnType = payloadType;
+        HandlerAsync = handlerAsync;
+    }
+
+    public async Task<ResponsePayload> HandleAsync(OcppSharpClient client, RequestPayload request)
+    {
+        if (Handler == null)
+        {
+            if (HandlerAsync == null)
+            {
+                throw new InvalidOperationException("No handler is set for this request type.");
+            }
+            return await HandlerAsync(client, request);
+        }
         return Handler(client, request);
     }
 }

--- a/ocpp-sharp/Client/Delegates.cs
+++ b/ocpp-sharp/Client/Delegates.cs
@@ -7,3 +7,11 @@ public delegate void RequestHandlerDelegate(OcppSharpClient client, Request requ
 
 public delegate ResponsePayload RequestPayloadHandlerDelegate(OcppSharpClient client, RequestPayload request);
 public delegate ResponsePayload RequestPayloadHandlerDelegateGeneric<T>(OcppSharpClient client, T request) where T : RequestPayload;
+
+
+public delegate Task ResponseHandlerDelegateAsync(OcppSharpClient client, Response response, string causeType);
+public delegate Task RequestHandlerDelegateAsync(OcppSharpClient client, Request request);
+
+
+public delegate Task<ResponsePayload> RequestPayloadHandlerDelegateAsync(OcppSharpClient client, RequestPayload request);
+public delegate Task<ResponsePayload> RequestPayloadHandlerDelegateGenericAsync<T>(OcppSharpClient client, T request) where T : RequestPayload;

--- a/ocpp-sharp/Client/OcppSharpClient.cs
+++ b/ocpp-sharp/Client/OcppSharpClient.cs
@@ -255,15 +255,7 @@ public class OcppSharpClient : IDisposable
         Dispose();
     }
 
-    /// <summary>
-    /// Registers a handler to this client instance for a specific type of OCPP-Request.
-    /// </summary>
-    /// <param name="payloadType">The type of request the handler is supposed to process. Must be a derived class of <see cref="RequestPayload"/>.</param>
-    /// <param name="handler">The handler to be executed upon receival of a request matching the type.</param>
-    /// <returns>A reference to the created <see cref="ClientRequestHandler"/>. This can be used to call <see cref="UnregisterHandler"/>.</returns>
-    /// <exception cref="ArgumentException">If a handler for this specific type has already been registered or an invalid type was given.</exception>
-    /// <exception cref="InvalidOperationException">If the payload is not meant to be received by a client (OCPP-Specification).</exception>
-    public virtual ClientRequestHandler RegisterHandler(Type payloadType, RequestPayloadHandlerDelegate handler)
+    private void CheckBeforeRegisteringHandler(Type payloadType)
     {
         if (handlers.Any(x => x.OnType == payloadType))
             throw new ArgumentException("A handler has already been registered for this type.", nameof(payloadType));
@@ -274,6 +266,27 @@ public class OcppSharpClient : IDisposable
         if (attr.Dir == OcppMessageAttribute.Direction.PointToCentral)
             throw new InvalidOperationException($"An OCPP-Message of type '{payloadType.Name}' cannot be received by a client (charge point) as per the OCPP-Specification.");
 
+    }
+    /// <summary>
+    /// Registers a handler to this client instance for a specific type of OCPP-Request.
+    /// </summary>
+    /// <param name="payloadType">The type of request the handler is supposed to process. Must be a derived class of <see cref="RequestPayload"/>.</param>
+    /// <param name="handler">The handler to be executed upon receival of a request matching the type.</param>
+    /// <returns>A reference to the created <see cref="ClientRequestHandler"/>. This can be used to call <see cref="UnregisterHandler"/>.</returns>
+    /// <exception cref="ArgumentException">If a handler for this specific type has already been registered or an invalid type was given.</exception>
+    /// <exception cref="InvalidOperationException">If the payload is not meant to be received by a client (OCPP-Specification).</exception>
+    public virtual ClientRequestHandler RegisterHandler(Type payloadType, RequestPayloadHandlerDelegate handler)
+    {
+        CheckBeforeRegisteringHandler(payloadType);
+        ClientRequestHandler result = new(payloadType, handler);
+        handlers.Add(result);
+
+        return result;
+    }
+
+    public virtual ClientRequestHandler RegisterAsyncHandler(Type payloadType, RequestPayloadHandlerDelegateAsync handler)
+    {
+        CheckBeforeRegisteringHandler(payloadType);
         ClientRequestHandler result = new(payloadType, handler);
         handlers.Add(result);
 
@@ -289,6 +302,14 @@ public class OcppSharpClient : IDisposable
     public virtual ClientRequestHandler RegisterHandler<T>(RequestPayloadHandlerDelegateGeneric<T> handler) where T : RequestPayload
     {
         return RegisterHandler(typeof(T), (server, request) =>
+        {
+            return handler(server, (T)request);
+        });
+    }
+
+    public virtual ClientRequestHandler RegisterAsyncHandler<T>(RequestPayloadHandlerDelegateGenericAsync<T> handler) where T : RequestPayload
+    {
+        return RegisterAsyncHandler(typeof(T), (server, request) =>
         {
             return handler(server, (T)request);
         });
@@ -383,7 +404,7 @@ public class OcppSharpClient : IDisposable
     /// <returns>The response payload resulting from the processing by the handler.</returns>
     /// <exception cref="KeyNotFoundException">If no handler for this OCPP message type has been registered.</exception>
     /// <exception cref="InvalidOperationException">If the payload is not meant to be received by a client (OCPP-Specification).</exception>
-    protected virtual ResponsePayload RunHandler(RequestPayload payload)
+    protected virtual async Task<ResponsePayload> RunHandler(RequestPayload payload)
     {
         Type payloadType = payload.GetType();
 
@@ -393,8 +414,7 @@ public class OcppSharpClient : IDisposable
         string? messageTypeName = OcppMessageAttribute.GetMessageIdentifier(payloadType);
         ClientRequestHandler? handler = handlers.FirstOrDefault(x => x.OnType == payloadType)
                                             ?? throw new KeyNotFoundException($"No handler registered for {messageTypeName}.");
-
-        return handler.Handle(this, payload);
+        return await handler.HandleAsync(this, payload);
     }
 
     /// <summary>
@@ -430,7 +450,7 @@ public class OcppSharpClient : IDisposable
                 }
 
                 // Handle the request
-                ResponsePayload payload = RunHandler(request.Payload);
+                ResponsePayload payload = await RunHandler(request.Payload);
 
                 // Make and send Response
                 Response response = new(request.MessageId)

--- a/ocpp-sharp/Server/Delegates.cs
+++ b/ocpp-sharp/Server/Delegates.cs
@@ -5,5 +5,19 @@ namespace OcppSharp.Server;
 public delegate void ResponseHandlerDelegate(OcppSharpServer server, OcppClientConnection sender, Response response, string causeType);
 public delegate void RequestHandlerDelegate(OcppSharpServer server, OcppClientConnection sender, Request request);
 
+
+
 public delegate ResponsePayload RequestPayloadHandlerDelegate(OcppSharpServer server, OcppClientConnection sender, RequestPayload request);
 public delegate ResponsePayload RequestPayloadHandlerDelegateGeneric<T>(OcppSharpServer server, OcppClientConnection sender, T request) where T : RequestPayload;
+
+
+//Async handlers
+
+
+public delegate Task ResponseHandlerDelegateAsync(OcppSharpServer server, OcppClientConnection sender, Response response, string causeType);
+public delegate Task RequestHandlerDelegateAsync(OcppSharpServer server, OcppClientConnection sender, Request request);
+
+
+
+public delegate Task<ResponsePayload> RequestPayloadHandlerDelegateAsync(OcppSharpServer server, OcppClientConnection sender, RequestPayload request);
+public delegate Task<ResponsePayload> RequestPayloadHandlerDelegateGenericAsync<T>(OcppSharpServer server, OcppClientConnection sender, T request) where T : RequestPayload;

--- a/ocpp-sharp/Server/OcppClientConnection.cs
+++ b/ocpp-sharp/Server/OcppClientConnection.cs
@@ -28,8 +28,8 @@ public class OcppClientConnection : OcppSharpClient
     public override void UnregisterHandler(ClientRequestHandler handler) => throw HandlerException;
 
     // Remove the original RunHandler logic and instead pass it to the parent server
-    protected override ResponsePayload RunHandler(RequestPayload payload)
+    protected override async Task<ResponsePayload> RunHandler(RequestPayload payload)
     {
-        return ParentServer.RunHandler(this, payload);
+        return await ParentServer.RunHandler(this, payload);
     }
 }

--- a/ocpp-sharp/Server/OcppSharpServer.cs
+++ b/ocpp-sharp/Server/OcppSharpServer.cs
@@ -244,15 +244,8 @@ public partial class OcppSharpServer
             throw new KeyNotFoundException($"The Station with id '{id}' does not exist.");
     }
 
-    /// <summary>
-    /// Registers a handler to this server instance for a specific type of OCPP-Request.
-    /// </summary>
-    /// <param name="payloadType">The type of request the handler is supposed to process. Must be a derived class of <see cref="RequestPayload"/>.</param>
-    /// <param name="handler">The handler to be executed upon receival of a request matching the type.</param>
-    /// <returns>A reference to the created <see cref="ServerRequestHandler"/>. This can be used to call <see cref="UnregisterHandler"/>.</returns>
-    /// <exception cref="ArgumentException">If a handler for this specific type has already been registered or an invalid type was given.</exception>
-    /// <exception cref="InvalidOperationException">If the payload is not meant to be received by a server (OCPP-Specification).</exception>
-    public ServerRequestHandler RegisterHandler(Type payloadType, RequestPayloadHandlerDelegate handler)
+
+    private bool CheckBeforeRegisteringHandler(Type payloadType)
     {
         if (handlers.Any(x => x.OnType == payloadType))
             throw new ArgumentException("A handler has already been registered for this type.", nameof(payloadType));
@@ -263,10 +256,40 @@ public partial class OcppSharpServer
         if (attr.Dir == OcppMessageAttribute.Direction.CentralToPoint)
             throw new InvalidOperationException($"An OCPP-Message of type '{payloadType.Name}' cannot be received by a server (central system) as per the OCPP-Specification.");
 
-        ServerRequestHandler result = new(payloadType, handler);
-        handlers.Add(result);
+        return true;
+    }
+    /// <summary>
+    /// Registers a handler to this server instance for a specific type of OCPP-Request.
+    /// </summary>
+    /// <param name="payloadType">The type of request the handler is supposed to process. Must be a derived class of <see cref="RequestPayload"/>.</param>
+    /// <param name="handler">The handler to be executed upon receival of a request matching the type.</param>
+    /// <returns>A reference to the created <see cref="ServerRequestHandler"/>. This can be used to call <see cref="UnregisterHandler"/>.</returns>
+    /// <exception cref="ArgumentException">If a handler for this specific type has already been registered or an invalid type was given.</exception>
+    /// <exception cref="InvalidOperationException">If the payload is not meant to be received by a server (OCPP-Specification).</exception>
+    public ServerRequestHandler RegisterHandler(Type payloadType, RequestPayloadHandlerDelegate handler)
+    {
+        if (CheckBeforeRegisteringHandler(payloadType))
+        {
+            ServerRequestHandler result = new(payloadType, handler);
+            handlers.Add(result);
 
-        return result;
+            return result;
+        }
+        else
+            throw new InvalidOperationException("Unknown error while registering handler.");
+    }
+
+    public ServerRequestHandler RegisterAsyncHandler(Type payloadType, RequestPayloadHandlerDelegateAsync handlerAsync)
+    {
+        if (CheckBeforeRegisteringHandler(payloadType))
+        {
+            ServerRequestHandler result = new(payloadType, handlerAsync);
+            handlers.Add(result);
+
+            return result;
+        }
+        else
+            throw new InvalidOperationException("Unknown error while registering handler.");
     }
 
     /// <summary>
@@ -278,6 +301,14 @@ public partial class OcppSharpServer
     public ServerRequestHandler RegisterHandler<T>(RequestPayloadHandlerDelegateGeneric<T> handler) where T : RequestPayload
     {
         return RegisterHandler(typeof(T), (server, sender, request) =>
+        {
+            return handler(server, sender, (T)request);
+        });
+    }
+
+    public ServerRequestHandler RegisterAsyncHandler<T>(RequestPayloadHandlerDelegateGenericAsync<T> handler) where T : RequestPayload
+    {
+        return RegisterAsyncHandler(typeof(T), (server, sender, request) =>
         {
             return handler(server, sender, (T)request);
         });
@@ -321,7 +352,7 @@ public partial class OcppSharpServer
         UnregisterEvents((OcppClientConnection)sender!);
     }
 
-    internal ResponsePayload RunHandler(OcppClientConnection client, RequestPayload payload)
+    internal async Task<ResponsePayload> RunHandler(OcppClientConnection client, RequestPayload payload)
     {
         Type payloadType = payload.GetType();
 
@@ -332,7 +363,7 @@ public partial class OcppSharpServer
         ServerRequestHandler? handler = handlers.FirstOrDefault(x => x.OnType == payloadType)
                                             ?? throw new KeyNotFoundException($"No handler registered for {messageTypeName}.");
 
-        return handler.Handle(this, client, payload);
+        return await handler.HandleAsync(this, client, payload);
     }
 
     private void RegisterEvents(OcppClientConnection client)

--- a/ocpp-sharp/Server/ServerRequestHandler.cs
+++ b/ocpp-sharp/Server/ServerRequestHandler.cs
@@ -5,7 +5,9 @@ namespace OcppSharp.Server;
 public class ServerRequestHandler
 {
     public Type OnType { get; }
-    public RequestPayloadHandlerDelegate Handler { get; }
+    public RequestPayloadHandlerDelegate? Handler { get; } = null;
+    public RequestPayloadHandlerDelegateAsync? HandlerAsync { get; } = null;
+
 
     public ServerRequestHandler(Type payloadType, RequestPayloadHandlerDelegate handler)
     {
@@ -13,8 +15,22 @@ public class ServerRequestHandler
         Handler = handler;
     }
 
-    public ResponsePayload Handle(OcppSharpServer server, OcppClientConnection station, RequestPayload request)
+    public ServerRequestHandler(Type payloadType, RequestPayloadHandlerDelegateAsync handlerAsync)
     {
+        OnType = payloadType;
+        HandlerAsync = handlerAsync;
+    }
+
+    public async Task<ResponsePayload> HandleAsync(OcppSharpServer server, OcppClientConnection station, RequestPayload request)
+    {
+        if (Handler == null)
+        {
+            if (HandlerAsync == null)
+            {
+                throw new InvalidOperationException("No handler is set for this request type.");
+            }
+            return await HandlerAsync(server, station, request);
+        }
         return Handler(server, station, request);
     }
 }


### PR DESCRIPTION
### Why this PR?

I'm building a custom CSMS for a personnal project and I needed to run some async code inside of the Handlers. In order to keep my code clean and don't use sync-over-async workarounds (like `.Result` or `.Wait()`) I needed to have async handlers.

So, this PR introduces native async response handler support

### Changes
- Create new delegates that returns Tasks instead of simple response payloads, for both the server and client

- Made the ServerRequestHandler take either sync or async Handlers and made his handle method async by default

- Add new RegisterAsyncHandler methods that adds new Async-Only Handlers in the handlers list

- Change the RunHandler methods in order to make them async by default

- Make the RunHandler methods awaits in the ProcessMessageAsync

### Checklist
- [X] Backward compatibility maintained for existing sync handlers
- [x] Code compiles successfully on .NET 8
- [X] Code is working with my current setup and when I tried with the [SAP e mobility simulator](https://github.com/SAP/e-mobility-charging-stations-simulator)